### PR TITLE
Fixed toUpperCase end limit

### DIFF
--- a/caseconv/caseconv.c
+++ b/caseconv/caseconv.c
@@ -7,7 +7,7 @@ void toUpperCase(char *string)
     int i;
     for (i = 0; i < strlen(string); i++)
     {
-        if (string[i] > 'Z')
+        if (string[i] > 'Z' && string[i] <= 'z')
         {
             string[i] = string[i] - 32;
         }


### PR DESCRIPTION
Fixed toUpperCase function. When we are using special characters that is beyond 'z' according to the ASCII table, the characters were getting replaced by other character.

Closes #